### PR TITLE
feat(Set|Map): Add Set and Map type utility functions

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -441,7 +441,7 @@ type LiteralKeys = MapKeyOf<LiteralMap>; // 'name' | 'age'
 Extracts the value type from a Map type.
 
 ```typescript
-type MapValueOf<T extends Map<any, any>> = T extends Map<any, infer V> ? V : never;
+type MapValueOf<T extends Map<unknown, unknown>> = T extends Map<unknown, infer V> ? V : never;
 ```
 
 #### Type Parameters
@@ -474,8 +474,8 @@ type UserValue = MapValueOf<UserMap>; // User
 Converts a Map type to an equivalent object type.
 
 ```typescript
-type MapToObject<T extends Map<any, any>> = {
-    [K in MapKeyOf<T> & PropertyKey]: T extends Map<any, infer V> ? V : never;
+type MapToObject<T extends Map<unknown, unknown>> = {
+    [K in MapKeyOf<T> & PropertyKey]: T extends Map<unknown, infer V> ? V : never;
 }
 ```
 
@@ -549,7 +549,7 @@ type ConfigMap = ObjectToMap<Config>;
 Creates a new Map type excluding specified keys.
 
 ```typescript
-type OmitMapKey<T extends Map<any, any>, K extends MapKeyOf<T>> = 
+type OmitMapKey<T extends Map<unknown, unknown>, K extends MapKeyOf<T>> = 
   T extends Map<infer Keys, infer V> ? Map<Exclude<Keys, K>, V> : never;
 ```
 
@@ -578,8 +578,8 @@ type WithoutNameAndAge = OmitMapKey<OriginalMap, 'name' | 'age'>;
 Creates a new Map type including only specified keys.
 
 ```typescript
-export type PickMapKey<T extends Map<any, any>, K extends MapKeyOf<T>> = 
-  T extends Map<any, infer V> ? Map<K, V> : never;
+export type PickMapKey<T extends Map<unknown, unknown>, K extends MapKeyOf<T>> = 
+  T extends Map<unknown, infer V> ? Map<K, V> : never;
 ```
 
 #### Type Parameters
@@ -607,7 +607,7 @@ type NameAndAge = PickMapKey<OriginalMap, 'name' | 'age'>;
 Extracts the element type from a Set type.
 
 ```typescript
-type SetValueOf<T extends Set<any>> = T extends Set<infer V> ? V : never;
+type SetValueOf<T extends ReadonlySet<unknown>> = T extends ReadonlySet<infer V> ? V : never;
 ```
 
 #### Type Parameters
@@ -645,7 +645,7 @@ type UserElement = SetValueOf<UserSet>; // User
 Creates a new Set type excluding specified value types.
 
 ```typescript
-type OmitSetValue<T extends Set<any>, V extends SetValueOf<T>> = 
+type OmitSetValue<T extends Set<unknown>, V extends SetValueOf<T>> = 
   T extends Set<infer Values> ? Set<Exclude<Values, V>> : never;
 ```
 
@@ -679,7 +679,7 @@ type WithoutOddNumbers = OmitSetValue<NumberSet, 1 | 3 | 5>;
 Creates a new Set type including only specified value types.
 
 ```typescript
-type PickSetValue<T extends Set<any>, V extends SetValueOf<T>> = Set<V>;
+type PickSetValue<T extends Set<unknown>, V extends SetValueOf<T>> = Set<V>;
 ```
 
 #### Type Parameters
@@ -708,7 +708,7 @@ type EvenNumbers = PickSetValue<NumberSet, 2 | 4>;
 Converts an array type to an equivalent Set type.
 
 ```typescript
-type ArrayToSet<T extends any[]> = Set<T[number]>;
+type ArrayToSet<T extends readonly unknown[]> = Set<T[number]>;
 ```
 
 #### Type Parameters
@@ -743,7 +743,7 @@ type FruitSet = ArrayToSet<typeof fruits>;
 Converts a Set type to an equivalent array type.
 
 ```typescript
-type SetToArray<T extends Set<any>> = SetValueOf<T>[];
+type SetToArray<T extends ReadonlySet<unknown>> = SetValueOf<T>[];
 ```
 
 #### Type Parameters

--- a/README.en.md
+++ b/README.en.md
@@ -407,6 +407,377 @@ interface User {
 type UserKeys = KeyOf<User>; // "id" | "name" | "age"
 ```
 
+### MapKeyOf<T>
+Extracts the key type from a Map type.
+
+```typescript
+type MapKeyOf<T extends Map<any, any>> = T extends Map<infer K, any> ? K : never;
+```
+
+#### Type Parameters
+- `T` : Any Map type
+
+#### Description
+- Uses conditional types and the `infer` keyword to extract the key type from a Map type
+- Returns a union type of all possible keys in the Map
+- Returns `never` if the input is not a Map type
+
+#### Example
+```typescript
+// Basic usage
+type StringNumberMap = Map<string, number>;
+type Keys = MapKeyOf<StringNumberMap>; // string
+
+// Union key type
+type UnionKeyMap = Map<string | number, boolean>;
+type UnionKeys = MapKeyOf<UnionKeyMap>; // string | number
+
+// Literal key type
+type LiteralMap = Map<'name' | 'age', string>;
+type LiteralKeys = MapKeyOf<LiteralMap>; // 'name' | 'age'
+```
+
+### MapValueOf<T>
+Extracts the value type from a Map type.
+
+```typescript
+type MapValueOf<T extends Map<any, any>> = T extends Map<any, infer V> ? V : never;
+```
+
+#### Type Parameters
+- `T`: Any Map type
+
+#### Description
+- Extracts the value type from a Map type
+- Returns a union type of all possible values in the Map
+
+#### Example
+```typescript
+// Basic usage
+type StringNumberMap = Map<string, number>;
+type Values = MapValueOf<StringNumberMap>; // number
+
+// Union value type
+type UnionValueMap = Map<string, number | boolean>;
+type UnionValues = MapValueOf<UnionValueMap>; // number | boolean
+
+// Object value type
+interface User {
+  id: number;
+  name: string;
+}
+type UserMap = Map<string, User>;
+type UserValue = MapValueOf<UserMap>; // User
+```
+
+### MapToObject<T>
+Converts a Map type to an equivalent object type.
+
+```typescript
+type MapToObject<T extends Map<any, any>> = {
+    [K in MapKeyOf<T> & PropertyKey]: T extends Map<any, infer V> ? V : never;
+}
+```
+
+#### Type Parameters
+- `T`: Any Map type
+
+#### Description
+- Converts a Map type to an equivalent object type
+- Only works correctly when the Map's key type is a subset of `PropertyKey` (string | number | symbol)
+- Preserves the original key-value relationships
+
+#### Example
+```typescript
+// String key Map
+type StringMap = Map<'name' | 'age', string>;
+type StringObject = MapToObject<StringMap>; 
+// { name: string; age: string; }
+
+// Numeric key Map
+type NumberMap = Map<1 | 2 | 3, boolean>;
+type NumberObject = MapToObject<NumberMap>;
+// { 1: boolean; 2: boolean; 3: boolean; }
+
+// Practical example
+const userMap: Map<'id' | 'name', string> = new Map([
+  ['id', '123'],
+  ['name', 'John']
+]);
+
+// Converted object type
+type UserObject = MapToObject<typeof userMap>;
+// { id: string; name: string; }
+```
+
+### ObjectToMap<T>
+Converts an object type to an equivalent Map type.
+
+```typescript
+type ObjectToMap<T extends AnyObject> = Map<keyof T, T[keyof T]>;
+```
+
+#### Type Parameters
+- `T`: Object type inheriting from `AnyObject`
+
+#### Description
+- Converts an object type to an equivalent Map type
+- Uses object keys as Map keys and object values as Map values
+
+#### Example
+```typescript
+// Basic object conversion
+interface User {
+  id: number;
+  name: string;
+  active: boolean;
+}
+type UserMap = ObjectToMap<User>;
+// Map<'id' | 'name' | 'active', number | string | boolean>
+
+// Configuration object conversion
+interface Config {
+  host: string;
+  port: number;
+  ssl: boolean;
+}
+type ConfigMap = ObjectToMap<Config>;
+// Map<'host' | 'port' | 'ssl', string | number | boolean>
+```
+
+### OmitMapKey<T, K>
+Creates a new Map type excluding specified keys.
+
+```typescript
+type OmitMapKey<T extends Map<any, any>, K extends MapKeyOf<T>> = 
+  T extends Map<infer Keys, infer V> ? Map<Exclude<Keys, K>, V> : never;
+```
+
+#### Type Parameters
+- `T`: Object type inheriting from AnyObject
+- `K`: Keys to exclude (must exist in T)
+
+#### Description
+- Creates a new Map type excluding specified keys
+- Preserves the original value type while removing specified key types
+- Similar to the Omit utility type for object types
+
+#### Example
+```typescript
+// Exclude single key
+type OriginalMap = Map<'name' | 'age' | 'email', string>;
+type WithoutEmail = OmitMapKey<OriginalMap, 'email'>;
+// Map<'name' | 'age', string>
+
+// Exclude multiple keys (using union type)
+type WithoutNameAndAge = OmitMapKey<OriginalMap, 'name' | 'age'>;
+// Map<'email', string>
+```
+
+### PickMapKey<T, K>
+Creates a new Map type including only specified keys.
+
+```typescript
+export type PickMapKey<T extends Map<any, any>, K extends MapKeyOf<T>> = 
+  T extends Map<any, infer V> ? Map<K, V> : never;
+```
+
+#### Type Parameters
+- `T`: Object type inheriting from AnyObject
+- `K`: Keys to include (must exist in T)
+
+#### Description
+- Creates a new Map type including only specified keys
+- Preserves the original value type while selecting specific key types
+- Similar to the Pick utility type for object types
+
+#### Example
+```typescript
+// Select single key
+type OriginalMap = Map<'name' | 'age' | 'email', string>;
+type OnlyName = PickMapKey<OriginalMap, 'name'>;
+// Map<'name', string>
+
+// Select multiple keys
+type NameAndAge = PickMapKey<OriginalMap, 'name' | 'age'>;
+// Map<'name' | 'age', string>
+```
+
+### SetValueOf<T>
+Extracts the element type from a Set type.
+
+```typescript
+type SetValueOf<T extends Set<any>> = T extends Set<infer V> ? V : never;
+```
+
+#### Type Parameters
+- `T`: Any Set type
+
+#### Description
+- Extracts the element type from a Set type using conditional types and `infer`
+- Returns a union type of all possible elements in the Set
+- Returns `never` if the input is not a Set type
+
+#### Example
+```typescript
+// Basic usage
+type StringSet = Set<string>;
+type StringElement = SetValueOf<StringSet>; // string
+
+// Union type elements
+type MixedSet = Set<string | number | boolean>;
+type MixedElement = SetValueOf<MixedSet>; // string | number | boolean
+
+// Literal type elements
+type LiteralSet = Set<'red' | 'green' | 'blue'>;
+type ColorElement = SetValueOf<LiteralSet>; // 'red' | 'green' | 'blue'
+
+// Object type elements
+interface User {
+  id: number;
+  name: string;
+}
+type UserSet = Set<User>;
+type UserElement = SetValueOf<UserSet>; // User
+```
+
+### OmitSetValue<T, V>
+Creates a new Set type excluding specified value types.
+
+```typescript
+type OmitSetValue<T extends Set<any>, V extends SetValueOf<T>> = 
+  T extends Set<infer Values> ? Set<Exclude<Values, V>> : never;
+```
+
+#### Type Parameters
+- `T`: Any Set type
+- `V`: Values to exclude (must exist in T)
+
+#### Description
+- Creates a new Set type excluding specified element types
+- Uses the Exclude utility type to remove specified types from the union
+- Useful for scenarios requiring removal of specific element types from Sets
+
+#### Example
+```typescript
+// Exclude single value type
+type OriginalSet = Set<'apple' | 'banana' | 'orange'>;
+type WithoutApple = OmitSetValue<OriginalSet, 'apple'>;
+// Set<'banana' | 'orange'>
+
+// Exclude multiple value types
+type WithoutFruits = OmitSetValue<OriginalSet, 'apple' | 'banana'>;
+// Set<'orange'>
+
+// Numeric example
+type NumberSet = Set<1 | 2 | 3 | 4 | 5>;
+type WithoutOddNumbers = OmitSetValue<NumberSet, 1 | 3 | 5>;
+// Set<2 | 4>
+```
+
+### PickSetValue<T, V>
+Creates a new Set type including only specified value types.
+
+```typescript
+type PickSetValue<T extends Set<any>, V extends SetValueOf<T>> = Set<V>;
+```
+
+#### Type Parameters
+- `T`: Any Set type
+- `V`: Values to include (must exist in T)
+
+#### Description
+- Creates a new Set type including only specified element types
+- Directly constructs a new Set with the specified value types
+- Useful for extracting specific element types from existing Sets
+
+#### Example
+```typescript
+// Select value types
+type OriginalSet = Set<'red' | 'green' | 'blue' | 'yellow'>;
+type PrimaryColors = PickSetValue<OriginalSet, 'red' | 'green' | 'blue'>;
+// Set<'red' | 'green' | 'blue'>
+
+// Numeric selection
+type NumberSet = Set<1 | 2 | 3 | 4 | 5>;
+type EvenNumbers = PickSetValue<NumberSet, 2 | 4>;
+// Set<2 | 4>
+```
+
+### ArrayToSet<T>
+Converts an array type to an equivalent Set type.
+
+```typescript
+type ArrayToSet<T extends any[]> = Set<T[number]>;
+```
+
+#### Type Parameters
+- T: Any array type
+
+#### Description
+- Converts an array type to an equivalent Set type
+- Uses indexed access type `T[number]` to extract element types
+- Automatically deduplicates repeating element types
+
+#### Example
+```typescript
+// Basic array conversion
+type StringArray = string[];
+type StringSet = ArrayToSet<StringArray>; // Set<string>
+
+// Tuple conversion
+type ColorTuple = ['red', 'green', 'blue', 'red'];
+type ColorSet = ArrayToSet<ColorTuple>; // Set<'red' | 'green' | 'blue'>
+
+// Union type array
+type MixedArray = (string | number)[];
+type MixedSet = ArrayToSet<MixedArray>; // Set<string | number>
+
+// Practical example
+const fruits = ['apple', 'banana', 'apple', 'orange'] as const;
+type FruitSet = ArrayToSet<typeof fruits>;
+// Set<'apple' | 'banana' | 'orange'>
+```
+
+### SetToArray<T>
+Converts a Set type to an equivalent array type.
+
+```typescript
+type SetToArray<T extends Set<any>> = SetValueOf<T>[];
+```
+
+#### Type Parameters
+- `T`: Any array type
+
+#### Description
+- Converts a Set type to an equivalent array type
+- Extracts element types using SetValueOf and creates an array type
+- Provides the inverse operation of ArrayToSet
+
+#### Example
+```typescript
+// Basic Set conversion
+type StringSet = Set<string>;
+type StringArray = SetToArray<StringSet>; // string[]
+
+// Literal Set conversion
+type ColorSet = Set<'red' | 'green' | 'blue'>;
+type ColorArray = SetToArray<ColorSet>; // ('red' | 'green' | 'blue')[]
+
+// Object Set conversion
+interface User {
+  id: number;
+  name: string;
+}
+type UserSet = Set<User>;
+type UserArray = SetToArray<UserSet>; // User[]
+
+// Practical example
+function convertSetToArray<T extends Set<any>>(set: T): SetToArray<T> {
+  return Array.from(set) as SetToArray<T>;
+}
+```
+
 ## 📝 Contribution Guide
 Feel free to submit `issues` or `pull requests` to help improve `Hook-Fetch`.
 

--- a/README.md
+++ b/README.md
@@ -415,6 +415,374 @@ interface User {
 type UserKeys = KeyOf<User>; // "id" | "name" | "age"
 ```
 
+### MapKeyOf<T>
+从 Map 类型中提取键类型。
+
+```typescript
+type MapKeyOf<T extends Map<any, any>> = T extends Map<infer K, any> ? K : never;
+```
+
+#### Type Parameters
+- `T` : 任意 Map 类型
+
+#### Description
+- 使用条件类型和 infer 关键字从 Map 类型中提取键的类型
+- 返回 Map 中所有可能键的联合类型
+- 如果传入的不是 Map 类型，则返回 `never`
+
+#### Example
+```typescript
+// 基础用法
+type StringNumberMap = Map<string, number>;
+type Keys = MapKeyOf<StringNumberMap>; // string
+
+// 联合键类型
+type UnionKeyMap = Map<string | number, boolean>;
+type UnionKeys = MapKeyOf<UnionKeyMap>; // string | number
+
+// 字面量键类型
+type LiteralMap = Map<'name' | 'age', string>;
+type LiteralKeys = MapKeyOf<LiteralMap>; // 'name' | 'age'
+```
+
+### MapValueOf<T>
+从 Map 类型中提取值类型。
+
+```typescript
+type MapValueOf<T extends Map<any, any>> = T extends Map<any, infer V> ? V : never;
+```
+
+#### Type Parameters
+- `T` : 任意 Map 类型
+
+#### Description
+- 从 Map 类型中提取值的类型
+- 返回 Map 中所有可能值的联合类型
+
+#### Example
+```typescript
+// 基础用法
+type StringNumberMap = Map<string, number>;
+type Values = MapValueOf<StringNumberMap>; // number
+
+// 联合值类型
+type UnionValueMap = Map<string, number | boolean>;
+type UnionValues = MapValueOf<UnionValueMap>; // number | boolean
+
+// 对象值类型
+interface User {
+  id: number;
+  name: string;
+}
+type UserMap = Map<string, User>;
+type UserValue = MapValueOf<UserMap>; // User
+```
+
+### MapToObject<T>
+将 Map 类型转换为对象类型。
+
+```typescript
+type MapToObject<T extends Map<any, any>> = {
+    [K in MapKeyOf<T> & PropertyKey]: T extends Map<any, infer V> ? V : never;
+}
+```
+
+#### Type Parameters
+- `T` : 任意 Map 类型
+
+#### Description
+- 将 Map 类型转换为等价的对象类型
+- 只有当 Map 的键类型是 PropertyKey`（string | number | symbol）`的子集时才能正确转换
+- 保持键值对应关系不变
+
+#### Example
+```typescript
+// 字符串键的 Map
+type StringMap = Map<'name' | 'age', string>;
+type StringObject = MapToObject<StringMap>; 
+// { name: string; age: string; }
+
+// 数字键的 Map
+type NumberMap = Map<1 | 2 | 3, boolean>;
+type NumberObject = MapToObject<NumberMap>;
+// { 1: boolean; 2: boolean; 3: boolean; }
+
+// 实际使用示例
+const userMap: Map<'id' | 'name', string> = new Map([
+  ['id', '123'],
+  ['name', '张三']
+]);
+
+// 转换后的对象类型
+type UserObject = MapToObject<typeof userMap>;
+// { id: string; name: string; }
+```
+
+### ObjectToMap<T>
+将 Map 类型转换为对象类型。
+
+```typescript
+type ObjectToMap<T extends AnyObject> = Map<keyof T, T[keyof T]>;
+```
+
+#### Type Parameters
+- `T` : 继承自 `AnyObject` 的对象类型
+
+#### Description
+- 将对象类型转换为等价的 Map 类型
+- 对象的键成为 Map 的键类型，对象的值成为 Map 的值类型
+
+#### Example
+```typescript
+// 基础对象转换
+interface User {
+  id: number;
+  name: string;
+  active: boolean;
+}
+type UserMap = ObjectToMap<User>;
+// Map<'id' | 'name' | 'active', number | string | boolean>
+
+// 配置对象转换
+interface Config {
+  host: string;
+  port: number;
+  ssl: boolean;
+}
+type ConfigMap = ObjectToMap<Config>;
+// Map<'host' | 'port' | 'ssl', string | number | boolean>
+```
+### OmitMapKey<T, K>
+从 Map 类型中排除指定键的。
+
+```typescript
+type OmitMapKey<T extends Map<any, any>, K extends MapKeyOf<T>> = 
+  T extends Map<infer Keys, infer V> ? Map<Exclude<Keys, K>, V> : never;
+```
+
+#### Type Parameters
+- `T` : 继承自 AnyObject 的对象类型
+- `K` : 要排除的键，必须是 T 中存在的键类型
+
+#### Description
+- 创建一个新的 Map 类型，排除指定的键
+- 保持值类型不变，只移除指定的键类型
+- 类似于对象类型的 Omit 工具类型
+
+#### Example
+```typescript
+// 排除单个键
+type OriginalMap = Map<'name' | 'age' | 'email', string>;
+type WithoutEmail = OmitMapKey<OriginalMap, 'email'>;
+// Map<'name' | 'age', string>
+
+// 排除多个键（使用联合类型）
+type WithoutNameAndAge = OmitMapKey<OriginalMap, 'name' | 'age'>;
+// Map<'email', string>
+```
+
+### PickMapKey<T, K>
+从 Map 类型中选择指定键的。
+
+```typescript
+export type PickMapKey<T extends Map<any, any>, K extends MapKeyOf<T>> = 
+  T extends Map<any, infer V> ? Map<K, V> : never;
+```
+
+#### Type Parameters
+- `T` : 继承自 `AnyObject` 的对象类型
+- `K` : 要排除的键，必须是 `T` 中存在的键类型
+
+#### Description
+- 创建一个新的 Map 类型，只包含指定的键
+- 保持值类型不变，只保留指定的键类型
+- 类似于对象类型的 Pick 工具类型
+
+#### Example
+```typescript
+// 选择单个键
+type OriginalMap = Map<'name' | 'age' | 'email', string>;
+type OnlyName = PickMapKey<OriginalMap, 'name'>;
+// Map<'name', string>
+
+// 选择多个键
+type NameAndAge = PickMapKey<OriginalMap, 'name' | 'age'>;
+// Map<'name' | 'age', string>
+```
+
+### SetValueOf<T>
+从 Set 类型中提取元素类型。
+
+```typescript
+type SetValueOf<T extends Set<any>> = T extends Set<infer V> ? V : never;
+```
+
+#### Type Parameters
+- `T` : 任意 Set 类型
+
+#### Description
+- 使用条件类型和 infer 关键字从 Set 类型中提取元素类型
+- 返回 Set 中所有可能元素的联合类型
+- 如果传入的不是 Set 类型，则返回 never
+
+#### Example
+```typescript
+// 基础用法
+type StringSet = Set<string>;
+type StringElement = SetValueOf<StringSet>; // string
+
+// 联合类型元素
+type MixedSet = Set<string | number | boolean>;
+type MixedElement = SetValueOf<MixedSet>; // string | number | boolean
+
+// 字面量类型元素
+type LiteralSet = Set<'red' | 'green' | 'blue'>;
+type ColorElement = SetValueOf<LiteralSet>; // 'red' | 'green' | 'blue'
+
+// 对象类型元素
+interface User {
+  id: number;
+  name: string;
+}
+type UserSet = Set<User>;
+type UserElement = SetValueOf<UserSet>; // User
+```
+
+### OmitSetValue<T, V>
+从 Set 类型中排除指定值的。
+
+```typescript
+type OmitSetValue<T extends Set<any>, V extends SetValueOf<T>> = 
+  T extends Set<infer Values> ? Set<Exclude<Values, V>> : never;
+```
+
+#### Type Parameters
+- `T` : 任意 Set 类型
+- `V` : 要排除的值，必须是 T 中存在的元素类型
+
+#### Description
+- 创建一个新的 Set 类型，排除指定的元素类型
+- 使用 Exclude 工具类型从联合类型中移除指定类型
+- 适用于需要从 Set 中移除特定元素类型的场景
+
+#### Example
+```typescript
+// 排除单个值类型
+type OriginalSet = Set<'apple' | 'banana' | 'orange'>;
+type WithoutApple = OmitSetValue<OriginalSet, 'apple'>;
+// Set<'banana' | 'orange'>
+
+// 排除多个值类型
+type WithoutFruits = OmitSetValue<OriginalSet, 'apple' | 'banana'>;
+// Set<'orange'>
+
+// 数字类型示例
+type NumberSet = Set<1 | 2 | 3 | 4 | 5>;
+type WithoutOddNumbers = OmitSetValue<NumberSet, 1 | 3 | 5>;
+// Set<2 | 4>
+```
+
+### PickSetValue<T, V>
+从 Set 类型中选择指定值的。
+
+```typescript
+type PickSetValue<T extends Set<any>, V extends SetValueOf<T>> = Set<V>;
+```
+
+#### Type Parameters
+- `T` : 任意 Set 类型
+- `V` : 要排除的值，必须是 T 中存在的元素类型
+
+#### Description
+- 创建一个新的 Set 类型，只包含指定的元素类型
+- 直接使用指定的值类型创建新的 Set
+- 适用于需要从 Set 中提取特定元素类型的场景
+
+#### Example
+```typescript
+// 选择单个值类型
+type OriginalSet = Set<'red' | 'green' | 'blue' | 'yellow'>;
+type PrimaryColors = PickSetValue<OriginalSet, 'red' | 'green' | 'blue'>;
+// Set<'red' | 'green' | 'blue'>
+
+// 选择数字类型
+type NumberSet = Set<1 | 2 | 3 | 4 | 5>;
+type EvenNumbers = PickSetValue<NumberSet, 2 | 4>;
+// Set<2 | 4>
+```
+
+### ArrayToSet<T>
+将数组类型转换为 Set 类型的。
+
+```typescript
+type ArrayToSet<T extends any[]> = Set<T[number]>;
+```
+
+#### Type Parameters
+- `T` : 任意数组类型
+
+#### Description
+- 将数组类型转换为等价的 Set 类型
+- 使用索引访问类型 `T[number]` 获取数组元素类型
+- Set 会自动去重，所以重复的元素类型只会出现一次
+
+#### Example
+```typescript
+// 基础数组转换
+type StringArray = string[];
+type StringSet = ArrayToSet<StringArray>; // Set<string>
+
+// 元组转换
+type ColorTuple = ['red', 'green', 'blue', 'red'];
+type ColorSet = ArrayToSet<ColorTuple>; // Set<'red' | 'green' | 'blue'>
+
+// 联合类型数组
+type MixedArray = (string | number)[];
+type MixedSet = ArrayToSet<MixedArray>; // Set<string | number>
+
+// 实际使用示例
+const fruits = ['apple', 'banana', 'apple', 'orange'] as const;
+type FruitSet = ArrayToSet<typeof fruits>;
+// Set<'apple' | 'banana' | 'orange'>
+```
+
+### SetToArray<T>
+将 Set 类型转换为数组类型的。
+
+```typescript
+type SetToArray<T extends Set<any>> = SetValueOf<T>[];
+```
+
+#### Type Parameters
+- `T` : 任意数组类型
+
+#### Description
+- 将 Set 类型转换为等价的数组类型
+- 使用 SetValueOf 提取 Set 的元素类型，然后创建数组类型
+
+#### Example
+```typescript
+// 基础 Set 转换
+type StringSet = Set<string>;
+type StringArray = SetToArray<StringSet>; // string[]
+
+// 字面量 Set 转换
+type ColorSet = Set<'red' | 'green' | 'blue'>;
+type ColorArray = SetToArray<ColorSet>; // ('red' | 'green' | 'blue')[]
+
+// 对象 Set 转换
+interface User {
+  id: number;
+  name: string;
+}
+type UserSet = Set<User>;
+type UserArray = SetToArray<UserSet>; // User[]
+
+// 实际使用示例
+function convertSetToArray<T extends Set<any>>(set: T): SetToArray<T> {
+  return Array.from(set) as SetToArray<T>;
+}
+```
 
 ## 📝 贡献指南
 欢迎提交`issue`或`pull request`，共同完善`Hook-Fetch`。

--- a/README.md
+++ b/README.md
@@ -519,14 +519,14 @@ type UserObject = MapToObject<typeof userMap>;
 ```
 
 ### ObjectToMap<T>
-将 Map 类型转换为对象类型。
+将对象型转换为Map类型。
 
 ```typescript
 type ObjectToMap<T extends AnyObject> = Map<keyof T, T[keyof T]>;
 ```
 
 #### Type Parameters
-- `T` : 继承自 `AnyObject` 的对象类型
+- `T` : 任意继承自 `AnyObject` 的对象类型
 
 #### Description
 - 将对象类型转换为等价的 Map 类型

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ type UserKeys = KeyOf<User>; // "id" | "name" | "age"
 从 Map 类型中提取键类型。
 
 ```typescript
-type MapKeyOf<T extends Map<any, any>> = T extends Map<infer K, any> ? K : never;
+type MapKeyOf<T extends Map<unknown, unknown>> = T extends Map<infer K, unknown> ? K : never;
 ```
 
 #### Type Parameters
@@ -449,7 +449,7 @@ type LiteralKeys = MapKeyOf<LiteralMap>; // 'name' | 'age'
 从 Map 类型中提取值类型。
 
 ```typescript
-type MapValueOf<T extends Map<any, any>> = T extends Map<any, infer V> ? V : never;
+type MapValueOf<T extends Map<unknown, unknown>> = T extends Map<unknown, infer V> ? V : never;
 ```
 
 #### Type Parameters
@@ -482,8 +482,8 @@ type UserValue = MapValueOf<UserMap>; // User
 将 Map 类型转换为对象类型。
 
 ```typescript
-type MapToObject<T extends Map<any, any>> = {
-    [K in MapKeyOf<T> & PropertyKey]: T extends Map<any, infer V> ? V : never;
+type MapToObject<T extends Map<unknown, unknown>> = {
+    [K in MapKeyOf<T> & PropertyKey]: T extends Map<unknown, infer V> ? V : never;
 }
 ```
 
@@ -556,7 +556,7 @@ type ConfigMap = ObjectToMap<Config>;
 从 Map 类型中排除指定键的。
 
 ```typescript
-type OmitMapKey<T extends Map<any, any>, K extends MapKeyOf<T>> = 
+type OmitMapKey<T extends Map<unknown, unknown>, K extends MapKeyOf<T>> = 
   T extends Map<infer Keys, infer V> ? Map<Exclude<Keys, K>, V> : never;
 ```
 
@@ -585,8 +585,8 @@ type WithoutNameAndAge = OmitMapKey<OriginalMap, 'name' | 'age'>;
 从 Map 类型中选择指定键的。
 
 ```typescript
-export type PickMapKey<T extends Map<any, any>, K extends MapKeyOf<T>> = 
-  T extends Map<any, infer V> ? Map<K, V> : never;
+export type PickMapKey<T extends Map<unknown, unknown>, K extends MapKeyOf<T>> = 
+  T extends Map<unknown, infer V> ? Map<K, V> : never;
 ```
 
 #### Type Parameters
@@ -614,7 +614,8 @@ type NameAndAge = PickMapKey<OriginalMap, 'name' | 'age'>;
 从 Set 类型中提取元素类型。
 
 ```typescript
-type SetValueOf<T extends Set<any>> = T extends Set<infer V> ? V : never;
+type SetValueOf<T extends ReadonlySet<unknown>> = 
+  T extends ReadonlySet<infer V> ? V : never;
 ```
 
 #### Type Parameters
@@ -652,7 +653,7 @@ type UserElement = SetValueOf<UserSet>; // User
 从 Set 类型中排除指定值的。
 
 ```typescript
-type OmitSetValue<T extends Set<any>, V extends SetValueOf<T>> = 
+type OmitSetValue<T extends Set<unknown>, V extends SetValueOf<T>> = 
   T extends Set<infer Values> ? Set<Exclude<Values, V>> : never;
 ```
 
@@ -686,7 +687,7 @@ type WithoutOddNumbers = OmitSetValue<NumberSet, 1 | 3 | 5>;
 从 Set 类型中选择指定值的。
 
 ```typescript
-type PickSetValue<T extends Set<any>, V extends SetValueOf<T>> = Set<V>;
+type PickSetValue<T extends Set<unknown>, V extends SetValueOf<T>> = Set<V>;
 ```
 
 #### Type Parameters
@@ -715,7 +716,7 @@ type EvenNumbers = PickSetValue<NumberSet, 2 | 4>;
 将数组类型转换为 Set 类型的。
 
 ```typescript
-type ArrayToSet<T extends any[]> = Set<T[number]>;
+type ArrayToSet<T extends readonly unknown[]> = Set<T[number]>;
 ```
 
 #### Type Parameters
@@ -750,7 +751,7 @@ type FruitSet = ArrayToSet<typeof fruits>;
 将 Set 类型转换为数组类型的。
 
 ```typescript
-type SetToArray<T extends Set<any>> = SetValueOf<T>[];
+type SetToArray<T extends ReadonlySet<unknown>> = SetValueOf<T>[];
 ```
 
 #### Type Parameters

--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -1,0 +1,17 @@
+import type { AnyObject } from './object'
+
+export type MapKeyOf<T extends Map<any, any>> = T extends Map<infer K, any> ? K : never;
+
+export type MapValueOf<T extends Map<any, any>> = T extends Map<any, infer V> ? V : never;
+
+export type MapToObject<T extends Map<any, any>> = {
+    [K in MapKeyOf<T> & PropertyKey]: T extends Map<any, infer V> ? V : never;
+};
+ 
+export type ObjectToMap<T extends AnyObject> = Map<keyof T, T[keyof T]>;
+
+export type OmitMapKey<T extends Map<any, any>, K extends MapKeyOf<T>> = 
+  T extends Map<infer Keys, infer V> ? Map<Exclude<Keys, K>, V> : never;
+
+export type PickMapKey<T extends Map<any, any>, K extends MapKeyOf<T>> = 
+  T extends Map<any, infer V> ? Map<K, V> : never;

--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -1,17 +1,19 @@
 import type { AnyObject } from './object'
 
-export type MapKeyOf<T extends Map<any, any>> = T extends Map<infer K, any> ? K : never;
+export type MapKeyOf<T extends Map<unknown, unknown>> =
+  T extends Map<infer K, unknown> ? K : never;
+  
+export type MapValueOf<T extends Map<unknown, unknown>> =
+  T extends Map<unknown, infer V> ? V : never;
 
-export type MapValueOf<T extends Map<any, any>> = T extends Map<any, infer V> ? V : never;
-
-export type MapToObject<T extends Map<any, any>> = {
-    [K in MapKeyOf<T> & PropertyKey]: T extends Map<any, infer V> ? V : never;
+export type MapToObject<T extends Map<unknown, unknown>> = {
+    [K in MapKeyOf<T> & PropertyKey]: T extends Map<unknown, infer V> ? V : never;
 };
  
 export type ObjectToMap<T extends AnyObject> = Map<keyof T, T[keyof T]>;
 
-export type OmitMapKey<T extends Map<any, any>, K extends MapKeyOf<T>> = 
+export type OmitMapKey<T extends Map<unknown, unknown>, K extends MapKeyOf<T>> = 
   T extends Map<infer Keys, infer V> ? Map<Exclude<Keys, K>, V> : never;
 
-export type PickMapKey<T extends Map<any, any>, K extends MapKeyOf<T>> = 
-  T extends Map<any, infer V> ? Map<K, V> : never;
+export type PickMapKey<T extends Map<unknown, unknown>, K extends MapKeyOf<T>> = 
+  T extends Map<unknown, infer V> ? Map<K, V> : never;

--- a/types/set.d.ts
+++ b/types/set.d.ts
@@ -1,10 +1,11 @@
-export type SetValueOf<T extends Set<any>> = T extends Set<infer V> ? V : never;
+export type SetValueOf<T extends ReadonlySet<unknown>> = 
+  T extends ReadonlySet<infer V> ? V : never;
 
-export type OmitSetValue<T extends Set<any>, V extends SetValueOf<T>> = 
+export type OmitSetValue<T extends Set<unknown>, V extends SetValueOf<T>> = 
   T extends Set<infer Values> ? Set<Exclude<Values, V>> : never;
 
-export type PickSetValue<T extends Set<any>, V extends SetValueOf<T>> = Set<V>;
+export type PickSetValue<T extends Set<unknown>, V extends SetValueOf<T>> = Set<V>;
 
-export type ArrayToSet<T extends any[]> = Set<T[number]>;
+export type ArrayToSet<T extends readonly unknown[]> = Set<T[number]>;
 
-export type SetToArray<T extends Set<any>> = SetValueOf<T>[];
+export type SetToArray<T extends ReadonlySet<unknown>> = SetValueOf<T>[];

--- a/types/set.d.ts
+++ b/types/set.d.ts
@@ -1,0 +1,10 @@
+export type SetValueOf<T extends Set<any>> = T extends Set<infer V> ? V : never;
+
+export type OmitSetValue<T extends Set<any>, V extends SetValueOf<T>> = 
+  T extends Set<infer Values> ? Set<Exclude<Values, V>> : never;
+
+export type PickSetValue<T extends Set<any>, V extends SetValueOf<T>> = Set<V>;
+
+export type ArrayToSet<T extends any[]> = Set<T[number]>;
+
+export type SetToArray<T extends Set<any>> = SetValueOf<T>[];


### PR DESCRIPTION
新增：
1. Map 类型
> MapKeyOf / MapValueOf / MapToObject / ObjectToMap / OmitMapKey / PickMapKey
2. Set 类型
> SetValueOf / OmitSetValue / PickSetValue / ArrayToSet / SetToArray 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive set of TypeScript utility types for working with `Map` and `Set`, including key/value extraction, type conversions between objects, arrays, maps, and sets, and utilities for including or excluding specific keys or values.
* **Documentation**
  * Added detailed descriptions and usage examples for all new utility types in the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->